### PR TITLE
Fix dupe

### DIFF
--- a/Plugin/src/main/java/xyz/oribuin/auctionhouse/gui/ExpiredAuctionsMenu.java
+++ b/Plugin/src/main/java/xyz/oribuin/auctionhouse/gui/ExpiredAuctionsMenu.java
@@ -110,10 +110,13 @@ public class ExpiredAuctionsMenu extends OriMenu {
 
             gui.addPageItem(baseItem, event -> {
                 ItemStack item = value.getItem().clone();
-                if (player.getInventory().addItem(item).isEmpty()) {
+                if (player.getInventory().firstEmpty() != -1) {
                     auctionManager.deleteAuction(value);
                     // Do this sync to prevent duplicate items
-                    this.sync(() -> this.setAuctions(gui, player));
+                    this.sync(() -> {
+                        player.getInventory().addItem(item);
+                        this.setAuctions(gui, player);
+                    });
                 }
             });
 

--- a/Plugin/src/main/java/xyz/oribuin/auctionhouse/gui/PersonalAuctionsMenu.java
+++ b/Plugin/src/main/java/xyz/oribuin/auctionhouse/gui/PersonalAuctionsMenu.java
@@ -115,9 +115,12 @@ public class PersonalAuctionsMenu extends OriMenu {
                     }
 
                     ItemStack item = value.getItem().clone();
-                    if (player.getInventory().addItem(item).isEmpty()) {
+                    if (player.getInventory().firstEmpty() != -1) {
                         auctionManager.deleteAuction(value);
-                        this.sync(() -> this.setAuctions(gui, player));
+                        this.sync(() -> {
+                            player.getInventory().addItem(item);
+                            this.setAuctions(gui, player);
+                        });
                     }
                 });
             });

--- a/Plugin/src/main/java/xyz/oribuin/auctionhouse/manager/AuctionManager.java
+++ b/Plugin/src/main/java/xyz/oribuin/auctionhouse/manager/AuctionManager.java
@@ -178,10 +178,12 @@ public class AuctionManager extends Manager {
 
         // Remove the item and check if it has been removed
         ItemStack item = auction.getItem();
-        if (!player.getInventory().addItem(item).isEmpty()) {
+        if (player.getInventory().firstEmpty() == -1) {
             locale.sendMessage(player, "command-buy-no-space");
             return;
         }
+
+        player.getInventory().addItem(item);
 
         auction.setSoldTime(System.currentTimeMillis());
         auction.setSold(true);


### PR DESCRIPTION
Currently, checking if an inventory has space is done with `player.getInventory().addItem()` and checking the returned map. This attempts to add items regardless of if there is sufficient space, and only invalidates the auctioned item if the player's inventory accepted all the items. With this, there are instances where duplication is possible. This PR separates and changes that check to `player.getInventory().firstEmpty() != -1` to ensure that there is an open slot before giving an item to the player.