### PR TITLE
Check the auction's real price when buying

### DIFF
--- a/src/main/java/xyz/oribuin/auctionhouse/manager/AuctionManager.java
+++ b/src/main/java/xyz/oribuin/auctionhouse/manager/AuctionManager.java
@@ -190,7 +190,7 @@ public class AuctionManager extends Manager {
 
         double playerBalance = VaultHook.getEconomy().getBalance(player);
 
-        if (buyPrice > playerBalance) {
+        if (auction.getPrice() > playerBalance) {
             locale.sendMessage(player, "invalid-funds", StringPlaceholders.builder().addPlaceholder("price", PluginUtils.formatCurrency(buyPrice)).build());
             return;
         }


### PR DESCRIPTION
Currently, it's possible to attempt withdrawing more than the player may have, resulting in nothing being taken at all. This PR fixes that by checking the amount to be withdrawn.

Closes #2