### PR TITLE
Clone the item before sending it to the gui

### DIFF
--- a/src/main/java/xyz/oribuin/auctionhouse/gui/ConfirmMenu.java
+++ b/src/main/java/xyz/oribuin/auctionhouse/gui/ConfirmMenu.java
@@ -44,7 +44,7 @@ public class ConfirmMenu extends OriMenu {
 
         if (this.get("auction-item.enabled", true)) {
             List<Integer> auctionSlots = this.parseList(this.get("auction-item.slots", List.of("4-4")));
-            gui.setItem(auctionSlots, new GuiItem(auction.getItem()));
+            gui.setItem(auctionSlots, new GuiItem(auction.getItem().clone()));
         }
 
         final ConfigurationSection extra = this.config.getConfigurationSection("extra-items");


### PR DESCRIPTION
triumph-gui mutates ItemStacks passed to it. In menus other than the confirm menu, auctioned items are cloned when passing it to triumph-gui. This PR extends that to the confirm menu

Closes #4